### PR TITLE
IP logging on 404 statuses

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-var createError = require('http-errors');
 var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');

--- a/app.js
+++ b/app.js
@@ -26,7 +26,9 @@ app.use('/api', api);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
-  next(createError(404));
+  var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  console.log(ip)
+  res.status(404).send('You took a wrong turn somewhere.')
 });
 
 var server = app.listen(8080, () => console.log("app running on port.", server.address().port));


### PR DESCRIPTION
This pull request will log the IP of the client, when they encounter a 404. This is due to the amount of 404 requests, the we have recieved recently, where the client has tried to access some page that is known to have a vulnerability. We of course don't have such pages, but it is taking up a lot of space in the console.